### PR TITLE
Fix(api): Align test-interview endpoint with frontend

### DIFF
--- a/backend/routes/single.py
+++ b/backend/routes/single.py
@@ -91,20 +91,15 @@ def test_interview():
     """Tests the connection to the AlphaRun interview API."""
     current_app.logger.info("\n--- Endpoint Hit: /api/test-interview ---")
     data = request.get_json()
-    candidate_slug = data.get('candidate_slug')
-    job_slug = data.get('job_slug')
+    interview_id = data.get('interview_id')
     alpharun_job_id = data.get('alpharun_job_id')
 
-    if not candidate_slug or not alpharun_job_id:
-        return jsonify({'error': 'Missing candidate_slug or alpharun_job_id'}), 400
+    if not interview_id or not alpharun_job_id:
+        return jsonify({'error': 'Missing interview_id or alpharun_job_id'}), 400
 
-    raw_interview_id = fetch_candidate_interview_id(candidate_slug, job_slug)
-
-    if not raw_interview_id:
-        return jsonify({'error': 'AI Interview ID not found for this candidate.'}), 404
-
-    interview_id = raw_interview_id.split('?')[0]
+    # The interview_id from the frontend is already cleaned by the /test-candidate endpoint.
     interview_data = fetch_alpharun_interview(alpharun_job_id, interview_id)
+
     if interview_data:
         contact = interview_data.get('data', {}).get('interview', {}).get('contact', {})
         return jsonify({


### PR DESCRIPTION
The `/api/test-interview` endpoint was expecting `candidate_slug` and `job_slug` as parameters, but the frontend was sending `interview_id` and `alpharun_job_id`.

This commit updates the `test_interview` function in `backend/routes/single.py` to expect `interview_id` and `alpharun_job_id`, which aligns it with the existing frontend implementation in `CandidateSummaryGenerator.jsx` and resolves the error.