### PR TITLE
Fix information leakage in test_quil route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-01 - [Prevent Information Leakage via Stack Traces]
+**Vulnerability:** Internal stack traces were being exposed to the client in the `/api/test-quil` endpoint during error conditions.
+**Learning:** Using `traceback.format_exc()` in API responses is a security risk as it exposes internal code structure, library versions, and potentially sensitive environment details to any user of the endpoint.
+**Prevention:** Always log the full stack trace on the server for debugging purposes but return a generic, non-descriptive error message to the client.

--- a/backend/routes/single.py
+++ b/backend/routes/single.py
@@ -232,9 +232,10 @@ def test_quil():
             return jsonify({'error': 'Quil notes found but matching failed'}), 500
             
     except Exception as e:
+        # CRITICAL: We log the full error with exc_info on the server,
+        # but we do NOT return the traceback to the client to prevent info leakage.
         log.error("single.test_quil.error", error=str(e), exc_info=True)
-        import traceback
-        return jsonify({'error': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'error': 'An internal error occurred while testing Quil integration'}), 500
 
 @single_bp.route('/test-resume', methods=['POST'])
 def test_resume():


### PR DESCRIPTION
Identified and fixed an information leakage vulnerability in the `test_quil` route within `backend/routes/single.py`. The endpoint was returning full Python stack traces to the client when an exception occurred. This has been replaced with a generic error message, while maintaining server-side logging with `exc_info=True`. Created a Sentinel journal entry in `.jules/sentinel.md` as per persona instructions.

---
*PR created automatically by Jules for task [5062263517395851944](https://jules.google.com/task/5062263517395851944) started by @steve-waters-outstaffer*