### PR TITLE
🛡️ Sentinel: Fix information leakage in single routes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-04-07 - [Information Leakage via Error Messages]
+**Vulnerability:** API endpoints were returning raw exception strings (`str(e)`) and stack traces (`traceback.format_exc()`) to the client in JSON responses.
+**Learning:** Returning internal error details can expose sensitive information about the application's code, structure, and environment to potential attackers.
+**Prevention:** Always log the full error on the server and return a generic, safe error message to the client. Ensure that `exc_info=True` is used in logs to maintain debuggability without compromising security.

--- a/backend/routes/single.py
+++ b/backend/routes/single.py
@@ -233,8 +233,7 @@ def test_quil():
             
     except Exception as e:
         log.error("single.test_quil.error", error=str(e), exc_info=True)
-        import traceback
-        return jsonify({'error': str(e), 'traceback': traceback.format_exc()}), 500
+        return jsonify({'error': 'An internal error occurred during Quil test'}), 500
 
 @single_bp.route('/test-resume', methods=['POST'])
 def test_resume():
@@ -398,7 +397,7 @@ def generate_summary():
 
     except Exception as e:
         log.error("single.generate_summary.error", error=str(e))
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred during summary generation'}), 500
 
 @single_bp.route('/push-to-recruitcrm', methods=['POST'])
 def push_to_recruitcrm():
@@ -434,7 +433,7 @@ def push_to_recruitcrm():
 
     except Exception as e:
         log.error("single.push_to_recruitcrm.exception", error=str(e))
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred while pushing to RecruitCRM'}), 500
 
 
 # --- NEW SIMPLIFIED ROUTE ---
@@ -467,7 +466,7 @@ def create_note():
 
     except Exception as e:
         log.error("single.create_note.exception", error=str(e), exc_info=True)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred while creating note'}), 500
 # --- END OF NEW ROUTE ---
 
 # --- ADD THIS NEW ROUTE ---
@@ -508,7 +507,7 @@ def move_stage():
 
     except Exception as e:
         log.error("single.move_stage.exception", error=str(e), exc_info=True)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred while moving stage'}), 500
 
 
 @single_bp.route('/create-gmail-draft', methods=['POST'])
@@ -556,7 +555,7 @@ def create_gmail_draft_route():
             
     except Exception as e:
         log.error("single.create_gmail_draft.exception", error=str(e))
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred while creating Gmail draft'}), 500
 
 @single_bp.route('/log-feedback', methods=['POST'])
 def log_feedback():
@@ -581,7 +580,7 @@ def log_feedback():
         return jsonify({'success': True, 'message': 'Feedback logged successfully'}), 200
     except Exception as e:
         log.error("single.log_feedback.error", error=str(e))
-        return jsonify({'error': f'An error occurred: {str(e)}'}), 500
+        return jsonify({'error': 'An internal error occurred while logging feedback'}), 500
 
 
 # --- ADD THIS NEW ROUTE ---
@@ -630,5 +629,5 @@ def track_event():
                   event_name=event_name,
                   user_id=user_id,
                   exc_info=True)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'An internal error occurred while tracking event'}), 500
 # --- END OF NEW ROUTE ---


### PR DESCRIPTION
I have hardened the `backend/routes/single.py` file to prevent information leakage through API error responses. 

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Information Exposure through Error Messages (CWE-209)
Raw exception strings and stack traces were being returned directly to the client in JSON responses, which could expose sensitive information about the application's internal structure and environment.

### 🎯 Impact: 
An attacker could gain insights into the application's codebase, library versions, and execution flow, facilitating further attacks or information gathering.

### 🔧 Fix:
Replaced all instances where `str(e)` or `traceback.format_exc()` were returned in `jsonify` responses with generic error messages (e.g., "An internal error occurred during Quil test"). The original exception details are still logged on the server using `structlog` for debugging purposes.

### ✅ Verification:
- Ran `python3 -m py_compile backend/routes/single.py` to ensure no syntax errors were introduced.
- Verified with `grep` that `str(e)` and `traceback.format_exc()` are no longer being returned in `jsonify` calls within `backend/routes/single.py`.
- Updated the `.jules/sentinel.md` journal to track this learning.

---
*PR created automatically by Jules for task [12167906420342311603](https://jules.google.com/task/12167906420342311603) started by @steve-waters-outstaffer*